### PR TITLE
[core] optimize loop frequency calculation

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -84,9 +84,7 @@ void Application::loop() {
   if (HighFrequencyLoopRequester::is_high_frequency()) {
     yield();
   } else {
-    uint32_t delay_time = this->loop_interval_;
-    if (now - this->last_loop_ < this->loop_interval_)
-      delay_time = this->loop_interval_ - (now - this->last_loop_);
+    uint32_t delay_time = std::min(this->loop_interval_, this->loop_interval_ - (now - last_loop_));
 
     uint32_t next_schedule = this->scheduler.next_schedule_in().value_or(delay_time);
     // next_schedule is max 0.5*delay_time
@@ -95,7 +93,7 @@ void Application::loop() {
     delay_time = std::min(next_schedule, delay_time);
     delay(delay_time);
   }
-  this->last_loop_ = now;
+  this->last_loop_ = millis();
 
   if (this->dump_config_at_ < this->components_.size()) {
     if (this->dump_config_at_ == 0) {


### PR DESCRIPTION
Now the code really tries to execute a loop every loop_interval milliseconds and doesn't add the delay time into the calculation.

# What does this implement/fix?
Fixes the calculation of the next loop call.

With the old code following behavior could happen:
If the whole loop took 10ms the delay would be 6ms after the delay lastloop gets set to the time before the sleep, it's already 6ms in the past if the next loop run takes 10ms again now - lastloop will be 16ms which causes the code to delay the next loop call for 16ms (all ignoring the scheduler). After this lastloop is 16ms in the past, even before the loop could run again, and now - lastloop will be again 16ms or higher. 


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
