### PR TITLE
fix: proper SPU usage

### DIFF
--- a/esphome/components/ds248x/ds248x.h
+++ b/esphome/components/ds248x/ds248x.h
@@ -44,7 +44,7 @@ class DS248xComponent : public PollingComponent, public i2c::I2CDevice {
   std::vector<DS248xTemperatureSensor *> sensors_;
 
   uint8_t read_config();
-  bool write_config(uint8_t cfg);
+  void write_config(uint8_t cfg);
 
   uint8_t wait_while_busy();
 


### PR DESCRIPTION
datasheet 
> The SPU bit must be set immediately prior to issuing the command that puts the 1-Wire device into the state where it needs the extra power.

which in our case is start conversion and read

> When the strong pullup ends, the SPU bit is automatically reset to 0. 

good to know as well